### PR TITLE
Handle FTP errors through promises

### DIFF
--- a/lib/api/video.js
+++ b/lib/api/video.js
@@ -13,16 +13,6 @@ const qs = require('qs')
  */
 class Video extends ApiResource {
   /**
-   * @constructor
-   *
-   * @param context
-   */
-  constructor (context) {
-    super(context)
-    this.ftp = new Ftp()
-  }
-
-  /**
    * Lists all videos on an account.
    *
    * @param {string} channelId - ID of a channel.
@@ -112,21 +102,13 @@ class Video extends ApiResource {
     const self = this
     let ext = file.originalname.substr(file.originalname.lastIndexOf('.') + 1)
 
-    return new Promise((resolve, reject) => {
-      this._initiateUpload(channelId, opts)
-        .then((res) => {
-          return self._ftpUpload(res.host, res.user, res.password, res.port, `${res.path}.${ext}`, file.stream)
-            .then(() => {
-              return self._completeUpload(channelId, res['videoId'], 'ready')
-            })
-        })
-        .then((res) => {
-          resolve(res)
-        })
-        .catch((err) => {
-          reject(err)
-        })
-    })
+    return this._initiateUpload(channelId, opts)
+      .then((res) => {
+        return self._ftpUpload(res.host, res.user, res.password, res.port, `${res.path}.${ext}`, file.stream)
+          .then(() => {
+            return self._completeUpload(channelId, res['videoId'], 'ready')
+          })
+      })
   }
 
   /**
@@ -215,18 +197,13 @@ class Video extends ApiResource {
     status = (status !== null) ? status : 'ready'
     let payload = qs.stringify({status: status})
 
-    return new Promise((resolve, reject) => {
-      this.context.authRequest('put', `/channels/${channelId}/uploads/${videoId}.json`, payload)
-        .then(() => {
-          resolve({
-            channelId: channelId,
-            videoId: videoId
-          })
+    return this.context.authRequest('put', `/channels/${channelId}/uploads/${videoId}.json`, payload)
+      .then(() => {
+        return Promise.resolve({
+          channelId: channelId,
+          videoId: videoId
         })
-        .catch((err) => {
-          reject(err)
-        })
-    })
+      })
   }
 }
 

--- a/lib/api/video.js
+++ b/lib/api/video.js
@@ -115,17 +115,13 @@ class Video extends ApiResource {
     return new Promise((resolve, reject) => {
       this._initiateUpload(channelId, opts)
         .then((res) => {
-          self._ftpUpload(res.host, res.user, res.password, res.port, `${res.path}.${ext}`, file.stream)
-            .then((err) => {
-              if (err) {
-                reject(new Error('Video could not be uploaded.'))
-              }
-
-              self._completeUpload(channelId, res['videoId'], 'ready')
-                .then((res) => {
-                  resolve(res)
-                })
+          return self._ftpUpload(res.host, res.user, res.password, res.port, `${res.path}.${ext}`, file.stream)
+            .then(() => {
+              return self._completeUpload(channelId, res['videoId'], 'ready')
             })
+        })
+        .then((res) => {
+          resolve(res)
         })
         .catch((err) => {
           reject(err)
@@ -173,7 +169,7 @@ class Video extends ApiResource {
     return new Promise((resolve, reject) => {
       ftp.binary((err) => {
         if (err) {
-          throw new Error('Failed to set FTP transfer type to binary.')
+          return reject(new Error('Failed to set FTP transfer type to binary.'))
         }
       })
 
@@ -182,11 +178,15 @@ class Video extends ApiResource {
           ftp.end()
 
           if (err) {
-            reject(new Error(err))
+            return reject(err)
           }
 
-          resolve(err)
+          return resolve()
         })
+      })
+
+      ftp.on('error', (err) => {
+        return reject(err)
       })
 
       ftp.connect({


### PR DESCRIPTION
Connected to issue https://github.com/MichaelJamesParsons/ustream-nodejs-sdk/issues/3.

## Problem
1. While uploading a video, the FTP handler does not listen for `error` events. Therefore, unexpected connection issues trigger uncaught errors.
2. The `ustream.video.upload()` method contains unnecessary `then()` and `catch()` statements which make the code bloated and error prone.

## Solution
1. Added a listener for `error` events in FTP handler.
2. Refactored usage of promises in methods related to the upload process.