### PR TITLE
More endpoints: device pwd, stream settings and featured videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ ustream.playlist.remove(channelId)
     - [ ] Video chapters
 - [ ] Channel
     - [x] List featured videos
-    - [ ] Update featured videos
+    - [x] Update featured videos
     - [ ] Get channel managers
     - [x] Channel metadata
         - [x] List metadata values

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ let ustream = new Ustream({
   redirect_uri: '...'
 })
 ```
+**Note**: The Analytics API uses only the jwt token type then isn't working with bearer.
 
 ### Oauth Demo App
 
@@ -585,6 +586,16 @@ ustream.playlist.remove(channelId)
     - [x] Update label
     - [x] List labels
     - [x] Delete label
+- [ ] Analytics
+    - []  List of unique viewers for all contents
+    - []  List of unique viewers for a specific content type
+    - [x] Raw view export for a given time period
+    - [x] Raw view export for a specific content type for a given time period
+    - []  Sum total view number for a given period for all contents
+    - []  Sum total view number for a given period and a specific content type
+    - []  Number of sum unique devices for a given period and all contents
+    - []  Number of sum unique devices for a given period and a specific content type
+    - ...
 - [ ] Other
     - [ ] Improve test coverage
 

--- a/README.md
+++ b/README.md
@@ -575,6 +575,13 @@ ustream.playlist.remove(channelId)
     - [x] Delete metadata field
 - [x] Ingest settings
     - [x] Get ingest settings
+- [x] User
+    - [x] List channels
+    - [x] List videos
+    - [x] Create label
+    - [x] Update label
+    - [x] List labels
+    - [x] Delete label
 - [ ] Other
     - [ ] Improve test coverage
 

--- a/README.md
+++ b/README.md
@@ -567,8 +567,8 @@ ustream.playlist.remove(channelId)
         - [x] List metadata display settings
         - [x] set metadata display setting
         - [x] remove metadata display setting
-- [ ] Stream settings
-    - [ ] Multi quality streaming
+- [x] Stream settings
+    - [x] Multi quality streaming
 - [x] Custom metadata
     - [x] List metadata fields
     - [x] Create new metadata field

--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ ustream.playlist.remove(channelId)
     - [x] List metadata fields
     - [x] Create new metadata field
     - [x] Delete metadata field
-- [ ] Ingest settings
-    - [ ] Get ingest settings
+- [x] Ingest settings
+    - [x] Get ingest settings
 - [ ] Other
     - [ ] Improve test coverage
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ ustream.playlist.remove(channelId)
         - [ ] Check copy status
     - [ ] Video chapters
 - [ ] Channel
-    - [ ] List featured videos
+    - [x] List featured videos
     - [ ] Update featured videos
     - [ ] Get channel managers
     - [x] Channel metadata

--- a/README.md
+++ b/README.md
@@ -515,10 +515,10 @@ ustream.playlist.remove(channelId)
 - [x] Authentication
     - [x] Oauth implicit flow
     - [x] Oauth authorization code flow
-- [ ] Device passwords
-    - [ ] Get device passwords
-    - [ ] Create device password
-    - [ ] Delete device password
+- [x] Device passwords
+    - [x] Get device passwords
+    - [x] Create device password
+    - [x] Delete device password
 - [ ] Playlists
     - [x] List the user's playlists
     - [x] Create a playlist

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ let ustream = new Ustream({
     password: "...",
     client_id: "...",
     client_secret: "...",
+    token_type: "...", // Optional, default is bearer
     type: "password"
 })
 
@@ -117,7 +118,8 @@ let ustream = new Ustream({
     username: '...',
     password: '...',
     client_id: '...',
-    client_secret: '...'
+    client_secret: '...',
+    token_type: "..." // Optional, default is bearer
 })
 ```
 
@@ -130,6 +132,7 @@ let ustream = new Ustream({
     scope: '...', // "broadcaster" or empty
     client_id: '...',
     client_secret: '...',
+    token_type: "..." // Optional, default is bearer
 })
 ```
 

--- a/lib/api/authorization/authorization_provider.js
+++ b/lib/api/authorization/authorization_provider.js
@@ -42,9 +42,9 @@ class AuthorizationProvider {
     switch (opts.type) {
       case 'client_credentials':
         return new ClientCredentialsStrategy(
-          this.context, opts.client_id, opts.client_secret, opts.device_name, opts.scope)
+          this.context, opts.client_id, opts.client_secret, opts.device_name, opts.scope, opts.token_type)
       case 'password':
-        return new PasswordStrategy(this.context, opts.username, opts.password, opts.client_id, opts.client_secret)
+        return new PasswordStrategy(this.context, opts.username, opts.password, opts.client_id, opts.client_secret, opts.token_type)
       case 'oauth_token':
         return new OAuthTokenStrategy(opts.access_token, opts.token_type, opts.expires_in)
       case 'oauth_code':

--- a/lib/api/authorization/client_credentials_strategy.js
+++ b/lib/api/authorization/client_credentials_strategy.js
@@ -17,12 +17,14 @@ class ClientCredentialsStrategy {
    * @param {string} deviceName - Device name.
    * @param {string} scope      - Currently, only use of the "broadcaster"
    *  scope is supported. If the parameter is empty, no scope will be set.
+   * @param {string} tokenType     - API token type.
    */
-  constructor (context, clientId, clientSecret, deviceName, scope) {
+  constructor (context, clientId, clientSecret, deviceName, scope, tokenType = 'bearer') {
     this.clientId = clientId
     this.clientSecret = clientSecret
     this.deviceName = deviceName
     this.scope = scope
+    this.tokenType = tokenType
     this.context = context
   }
 
@@ -37,7 +39,7 @@ class ClientCredentialsStrategy {
       client_id: this.clientId,
       device_name: this.deviceName,
       scope: this.scope,
-      token_type: 'bearer'
+      token_type: this.tokenType
     }), {
       'Authorization': `Basic ${this.clientSecret}`
     })

--- a/lib/api/authorization/password_strategy.js
+++ b/lib/api/authorization/password_strategy.js
@@ -13,14 +13,16 @@ class PasswordStrategy {
    * @param {Ustream} context
    * @param {string} username      - Ustream account username.
    * @param {string} password      - Ustream account password.
-   * @param {string} clientId     - API client ID.
-   * @param {string} clientSecret - API client secret.
+   * @param {string} clientId      - API client ID.
+   * @param {string} clientSecret  - API client secret.
+   * @param {string} tokenType     - API token type.
    */
-  constructor (context, username, password, clientId, clientSecret) {
+  constructor (context, username, password, clientId, clientSecret, tokenType = 'bearer') {
     this.username = username
     this.password = password
     this.clientId = clientId
     this.clientSecret = clientSecret
+    this.tokenType = tokenType
     this.context = context
   }
 
@@ -36,7 +38,7 @@ class PasswordStrategy {
       client_secret: this.clientSecret,
       username: this.username,
       password: this.password,
-      token_type: 'bearer'
+      token_type: this.tokenType
     }))
   }
 }

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -302,6 +302,20 @@ class Channel extends ApiResource {
     return this.context.authRequest('delete',
       `/channels/${channelId}/custom-metadata-display/${metadataId}.json`)
   }
+
+  /**
+   * Enable/disable channel's multi quality streaming
+   *
+   * @param {Number}   channelId
+   * @param {boolean}  isMulti
+   *
+   * @returns {Promise}
+   */
+  setMultiQualityStreaming (channelId, isMulti) {
+    return this.context.authRequest('put',
+      `/channels/${channelId}/settings/multi-quality.json`,
+      qs.stringify({value: isMulti}))
+  }
 }
 
 module.exports = Channel

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -316,6 +316,18 @@ class Channel extends ApiResource {
       `/channels/${channelId}/settings/multi-quality.json`,
       qs.stringify({value: isMulti}))
   }
+
+  /**
+   * Getting the channel's ingest settings: url and keys
+   *
+   * @param {Number}   channelId
+   *
+   * @returns {Promise}
+   */
+  getIngestSettings (channelId) {
+    return this.context.authRequest('get',
+      `/channels/${channelId}/ingest.json`)
+  }
 }
 
 module.exports = Channel

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -346,6 +346,20 @@ class Channel extends ApiResource {
           res.videos, res.paging))
       })
   }
+
+  /**
+   * Update channel featured videos
+   *
+   * @param {Number}   channelId
+   * @param {number[]}  video_ids   - List of existing video IDs
+   *
+   * @returns {Promise}
+   */
+  updateFeaturedVideos (channelId, videoIds) {
+    return this.context.authRequest('put',
+      `/channels/${channelId}/featured-videos.json`,
+      qs.stringify({video_ids: videoIds}))
+  }
 }
 
 module.exports = Channel

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -328,6 +328,24 @@ class Channel extends ApiResource {
     return this.context.authRequest('get',
       `/channels/${channelId}/ingest.json`)
   }
+
+  /**
+   * Lists channel's featured videos
+   *
+   * @param {Number} pagesize  - The number of results to show per page.
+   * @param {Number} page      - The page to retrieve.
+   * @returns {Promise}
+   */
+  getFeaturedVideos (pagesize = 100, page = 1) {
+    /** @var {{videos, paging}} res */
+    return this.context.authRequest(
+      'get',
+      `/channels/${channelId}/featured-videos.json${qs.stringify({pagesize, page})}`)
+      .then((res) => {
+        return Promise.resolve(new PageableApiResource(this.context, 'videos',
+          res.videos, res.paging))
+      })
+  }
 }
 
 module.exports = Channel

--- a/lib/api/channel.js
+++ b/lib/api/channel.js
@@ -325,8 +325,7 @@ class Channel extends ApiResource {
    * @returns {Promise}
    */
   getIngestSettings (channelId) {
-    return this.context.authRequest('get',
-      `/channels/${channelId}/ingest.json`)
+    return this.context.authRequest('get', `/channels/${channelId}/ingest.json`)
   }
 
   /**

--- a/lib/api/device_passwords.js
+++ b/lib/api/device_passwords.js
@@ -1,0 +1,54 @@
+const ApiResource = require('./api_resource')
+const qs = require('qs')
+
+/**
+ * @class DevicePasswords
+ */
+class DevicePasswords extends ApiResource {
+
+  /**
+   * Creates a device password
+   *
+   * @param {string}    device_name       - Device name
+   * @param {{}}        opts
+   * @param {string}    opts.valid_from   - The timestamp after which the device password is valid
+   * @param {string}    opts.valid_until  - The timestamp until the device password is valid
+   *
+   * @returns {*}
+   */
+  create (deviceName, opts = {}) {
+    opts.device_name = deviceName
+    return this.context.authRequest('post', '/users/self/device-passwords.json', qs.stringify(opts))
+  }
+
+  /**
+   * Lists device passwords with pagination
+   *
+   * @param {Number} pagesize  - The number of results to show per page.
+   * @param {Number} page      - The page to retrieve.
+   * @returns {Promise}
+   */
+  list (pagesize = 100, page = 1) {
+    /** @var {{device_passwords, paging}} res */
+    return this.context.authRequest(
+      'get',
+      `/users/self/device-passwords.json${qs.stringify({pagesize, page})}`)
+      .then((res) => {
+        return Promise.resolve(new PageableApiResource(this.context, 'device_passwords',
+          res.device_passwords, res.paging))
+      })
+  }
+
+  /**
+   * Deletes an existing device password by its username.
+   *
+   * @param {String} userName
+   *
+   * @returns {Promise}
+   */
+  remove (userName) {
+    return this.context.authRequest('delete', `/users/self/device-passwords/${userName}.json`)
+  }
+}
+
+module.exports = CustomMetadata

--- a/lib/api/device_passwords.js
+++ b/lib/api/device_passwords.js
@@ -51,4 +51,4 @@ class DevicePasswords extends ApiResource {
   }
 }
 
-module.exports = CustomMetadata
+module.exports = DevicePasswords

--- a/lib/api/pageable_api_resource.js
+++ b/lib/api/pageable_api_resource.js
@@ -8,15 +8,22 @@ class PageableApiResource extends ApiResource {
    *                             'paging'. The second property is holds the list of content (videos, channels, etc.).
    *                             This is the name of that second property.
    * @param {{href: {next},next}} paging
+   * @param {string} pagingProp - Sometimes paginated metadata comes in a different field like for the Analytics API
    */
-  constructor (context, dataProp, data, paging) {
+  constructor (context, dataProp, data, paging, pagingProp = 'paging') {
     super(context)
 
     this.data = data
     this.dataProp = dataProp
+    this.pagingProp = pagingProp
 
     if (paging.hasOwnProperty('next')) {
       this.nextPageUrl = paging.next.hasOwnProperty('href') ? paging.next.href : paging.next
+
+      // Fixing paginated urls not coming with the initial API endpoint
+      if (!this.nextPageUrl.startsWith('http')) {
+        this.nextPageUrl = this.context.getResourceUrl() + this.nextPageUrl.replace('/' + this.context.version, '');
+      }
     } else {
       this.nextPageUrl = null
     }
@@ -48,7 +55,7 @@ class PageableApiResource extends ApiResource {
        */
       this.context.authRequest('get', this.nextPageUrl)
         .then((res) => {
-          resolve(new PageableApiResource(this.context, this.dataProp, res[this.dataProp], res.paging))
+          resolve(new PageableApiResource(this.context, this.dataProp, res[this.dataProp], res[this.pagingProp], this.pagingProp))
         })
         .catch((err) => {
           reject(err)

--- a/lib/api/pageable_api_resource.js
+++ b/lib/api/pageable_api_resource.js
@@ -17,11 +17,11 @@ class PageableApiResource extends ApiResource {
     this.dataProp = dataProp
     this.pagingProp = pagingProp
 
-    if (paging.hasOwnProperty('next')) {
-      this.nextPageUrl = paging.next.hasOwnProperty('href') ? paging.next.href : paging.next
+    if (paging.next) {
+      this.nextPageUrl = paging.next.href ? paging.next.href : paging.next
 
       // Fixing paginated urls not coming with the initial API endpoint
-      if (!this.nextPageUrl.startsWith('http')) {
+      if (this.nextPageUrl && !this.nextPageUrl.startsWith('http')) {
         this.nextPageUrl = this.context.getResourceUrl() + this.nextPageUrl.replace('/' + this.context.version, '');
       }
     } else {

--- a/lib/api/user.js
+++ b/lib/api/user.js
@@ -1,4 +1,5 @@
 const ApiResource = require('./api_resource')
+const PageableApiResource = require('./pageable_api_resource')
 const qs = require('qs')
 
 /**
@@ -45,6 +46,25 @@ class User extends ApiResource {
    */
   deleteLabel (labelId) {
     return this.context.authRequest('delete', `/users/self/label/${labelId}.json`)
+  }
+
+  /**
+   * Lists all videos on the account.
+   *
+   * @param {Number} pageSize - The number of results to show per page.
+   * @param {Number} page - The page to retrieve.
+   *
+   * @returns {Promise}
+   */
+  listVideos (pageSize = 100, page = 1) {
+    /** @var {{videos, paging}} res */
+    return this.context.authRequest(
+      'get',
+      `/users/self/videos.json?${qs.stringify({pagesize: pageSize, page})}`)
+      .then((res) => {
+        return Promise.resolve(new PageableApiResource(this.context, 'videos',
+          res.videos, res.paging))
+      })
   }
 }
 

--- a/lib/api/video.js
+++ b/lib/api/video.js
@@ -341,6 +341,18 @@ class Video extends ApiResource {
         return Promise.resolve({channelId: channelId, videoId: videoId})
       })
   }
+
+  /**
+   * Select a frame as video's thumbnail.
+   *
+   * @param {Number} videoId - ID of existing video
+   * @param {{}} opts
+   * @param {string} opts.position - Video position in seconds
+   */
+  setFrameAsThumbnail (videoId, opts = {}) {
+    return this.context.authRequest('post', `/videos/${videoId}/thumbnail/frame.json`, qs.stringify(opts))
+  }
+
 }
 
 module.exports = Video

--- a/lib/api/video.js
+++ b/lib/api/video.js
@@ -36,9 +36,15 @@ class Video extends ApiResource {
    * Get video fields, including title, description, url, etc.
    *
    * @param {Number} videoId - ID of existing video
+   * @param {{}} opts
+   * @param {string} opts.detail_level - Verbosity level. Possible value:
+   *  "minimal". If set to "minimal", the result set is limited to id, title,
+   *  picture, owner and locks data. If the channel is protected, only minimal
+   *  data can be retrieved without valid access token.
+   *
    */
-  get (videoId) {
-    return this.context.authRequest('get', `/videos/${videoId}.json`)
+  get (videoId, opts = {}) {
+    return this.context.authRequest('get', `/videos/${videoId}.json?${qs.stringify(opts)}`)
       .then((res) => {
         return Promise.resolve(res.video)
       })

--- a/lib/api/view.js
+++ b/lib/api/view.js
@@ -1,0 +1,72 @@
+const ApiResource = require('./api_resource')
+const PageableApiResource = require('./pageable_api_resource')
+const qs = require('qs')
+
+/**
+ * Class View
+ *
+ * Implementation of Ustream's analytic API.
+ *
+ * @class
+ * @link https://developers.video.ibm.com/analytics-api/analytics.html
+ */
+class View extends ApiResource {
+
+  /**
+   * Lists all raw views segments in a time period.
+   *
+   * @param {Number} pageSize                       - The number of results to show per page.
+   * @param {Number} page                           - The page to retrieve.
+   * 
+   * @param {string} opts.date_time_from            - Start date for the query period in ISO8601
+   * @param {string} opts.date_time_to              - End date for the query period in ISO8601
+   * @param {string} opts.list_unfinished_segments  - Listing or not the unfinished segments, default is true
+   * @param {string} opts.inclusive_range           - Including or not the period delimiters (from & to dates), default is true
+   * @returns {Promise}
+   */
+  list (opts = {}, pageSize = 100, page = 1) {
+    opts._page = page;
+    opts._limit = pageSize;
+    
+    /** @var {{data, pagination}} res */
+    return this.context.authRequest(
+      'get',
+      `/views?${qs.stringify(opts)}`)
+      .then((res) => {
+        return Promise.resolve(new PageableApiResource(this.context, 'data',
+          res.data, res.pagination, 'pagination'))
+      })
+  }
+
+  /**
+   * Lists all raw views segments in a time period for a specific by content type
+   *
+   * @param {Number} contentType                    - Should be either live or recorded
+   * 
+   * @param {Number} pageSize                       - The number of results to show per page.
+   * @param {Number} page                           - The page to retrieve.
+   * 
+   * @param {string} opts.content_id                - Targetting a specific content (live or recorded video) by its ID
+   * @param {string} opts.date_time_from            - Start date for the query period in ISO8601
+   * @param {string} opts.date_time_to              - End date for the query period in ISO8601
+   * @param {string} opts.list_unfinished_segments  - Listing or not the unfinished segments, default is true
+   * @param {string} opts.inclusive_range           - Including or not the period delimiters (from & to dates), default is true
+   * @returns {Promise}
+   */
+  listByContentType (contentType, opts = {}, pageSize = 100, page = 1) {
+    opts._page = page;
+    opts._limit = pageSize;
+    
+    /** @var {{data, pagination}} res */
+    return this.context.authRequest(
+      'get',
+      `/views/${contentType}?${qs.stringify(opts)}`)
+      .then((res) => {
+        return Promise.resolve(new PageableApiResource(this.context, 'data',
+          res.data, res.pagination, 'pagination'))
+      })
+  }
+
+}
+
+module.exports = View

--- a/lib/ustream.js
+++ b/lib/ustream.js
@@ -6,6 +6,7 @@ const ChannelApi = require('./api/channel')
 const Playlist = require('./api/playlist')
 const User = require('./api/user')
 const CustomMetadata = require('./api/custom_metadata')
+const DevicePasswords = require('./api/device_passwords')
 
 const API_AUTH_ENDPOINT = 'https://www.ustream.tv'
 const API_RESOURCE_ENDPOINT = 'https://api.Ustream.tv'
@@ -32,6 +33,7 @@ class Ustream {
     this.playlist = new Playlist(this)
     this.user = new User(this)
     this.video = new VideoApi(this)
+    this.devicePasswords = new DevicePasswords(this)
   }
 
   /**

--- a/lib/ustream.js
+++ b/lib/ustream.js
@@ -10,7 +10,7 @@ const CustomMetadata = require('./api/custom_metadata')
 const DevicePasswords = require('./api/device_passwords')
 
 const API_AUTH_ENDPOINT = 'https://www.ustream.tv'
-let API_RESOURCE_ENDPOINT = 'https://api.Ustream.tv'
+const API_RESOURCE_ENDPOINT = 'https://api.Ustream.tv'
 
 /**
  * @class
@@ -24,9 +24,8 @@ class Ustream {
    * @see authenticate for additional information about opts.
    */
   constructor (opts) {
-    API_RESOURCE_ENDPOINT = opts.endpoint || API_RESOURCE_ENDPOINT; // Customized endpoint, usefull for analytic API
+    this.endpoint = opts.endpoint || API_RESOURCE_ENDPOINT;
 
-    // Specified token type and API version
     this.tokenType = opts.token_type
     this.version = opts.version
 
@@ -148,7 +147,7 @@ class Ustream {
    * @returns {string}
    */
   getResourceUrl () {
-    return this.version ? API_RESOURCE_ENDPOINT + '/' + this.version : API_RESOURCE_ENDPOINT
+    return this.version ? `${this.endpoint}/${this.version}` : this.endpoint;
   }
 
   /**
@@ -159,7 +158,9 @@ class Ustream {
    * @private
    */
   _buildAuthHeaders (headers = {}) {
-    headers['Authorization'] = this.tokenType === 'jwt' ? `${this.authToken.access_token}` : `Bearer ${this.authToken.access_token}`
+    headers['Authorization'] = this.tokenType === 'jwt'
+        ? `${this.authToken.access_token}`
+        : `Bearer ${this.authToken.access_token}`
     return headers
   }
 

--- a/lib/ustream.js
+++ b/lib/ustream.js
@@ -25,7 +25,10 @@ class Ustream {
   constructor (opts) {
     API_RESOURCE_ENDPOINT = opts.endpoint || API_RESOURCE_ENDPOINT; // Customized endpoint, usefull for analytic API
 
-    this.tokenType = opts.token_type  // Set token type
+    // Specified token type and API version
+    this.tokenType = opts.token_type
+    this.version = opts.version
+
     this.authToken = null
     this.httpClient = new RequestClient(this.getResourceUrl())
     this._authProvider = new AuthorizationProvider(this, opts)
@@ -143,7 +146,7 @@ class Ustream {
    * @returns {string}
    */
   getResourceUrl () {
-    return API_RESOURCE_ENDPOINT
+    return this.version ? API_RESOURCE_ENDPOINT + '/' + this.version : API_RESOURCE_ENDPOINT
   }
 
   /**

--- a/lib/ustream.js
+++ b/lib/ustream.js
@@ -2,6 +2,7 @@ const AuthorizationToken = require('./api/authorization/authorization_token')
 const RequestClient = require('./http/request_client')
 const AuthorizationProvider = require('./api/authorization/authorization_provider')
 const VideoApi = require('./api/video')
+const ViewApi = require('./api/view')
 const ChannelApi = require('./api/channel')
 const Playlist = require('./api/playlist')
 const User = require('./api/user')
@@ -39,6 +40,7 @@ class Ustream {
     this.playlist = new Playlist(this)
     this.user = new User(this)
     this.video = new VideoApi(this)
+    this.view = new ViewApi(this)
     this.devicePasswords = new DevicePasswords(this)
   }
 

--- a/lib/ustream.js
+++ b/lib/ustream.js
@@ -9,7 +9,7 @@ const CustomMetadata = require('./api/custom_metadata')
 const DevicePasswords = require('./api/device_passwords')
 
 const API_AUTH_ENDPOINT = 'https://www.ustream.tv'
-const API_RESOURCE_ENDPOINT = 'https://api.Ustream.tv'
+let API_RESOURCE_ENDPOINT = 'https://api.Ustream.tv'
 
 /**
  * @class
@@ -23,6 +23,9 @@ class Ustream {
    * @see authenticate for additional information about opts.
    */
   constructor (opts) {
+    API_RESOURCE_ENDPOINT = opts.endpoint || API_RESOURCE_ENDPOINT; // Customized endpoint, usefull for analytic API
+
+    this.tokenType = opts.token_type  // Set token type
     this.authToken = null
     this.httpClient = new RequestClient(this.getResourceUrl())
     this._authProvider = new AuthorizationProvider(this, opts)
@@ -151,7 +154,7 @@ class Ustream {
    * @private
    */
   _buildAuthHeaders (headers = {}) {
-    headers['Authorization'] = `Bearer ${this.authToken.access_token}`
+    headers['Authorization'] = this.tokenType === 'jwt' ? `${this.authToken.access_token}` : `Bearer ${this.authToken.access_token}`
     return headers
   }
 


### PR DESCRIPTION
- Get, create and delete device passwords
- Enable/disable stream settings
- Getting a channel Ingest Settings
- List featured videos
- Update channel featured video
- Set a video frame as the thumbnail
- List user/account videos
- Getting more video details with the verbosity level for owner
- Allow JWT as a token type  for the password and client_credentials strategies
- Improving the pagination, as the Analytics is using different fields
- Started the Analytics API: improved pagination & endpoint to query raw views for all and specific content type