### PR TITLE
Get a video downloadable details: URL, expiration and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ ustream.playlist.remove(channelId)
     - [ ] Playlist video
     - [x] Channel playlists
 - [ ] Video (new endpoints)
-    - [ ] Download video
+    - [x] Download video
     - [ ] Video expiration
     - [ ] Video thumbnail
     - [ ] Video labels

--- a/lib/api/video.js
+++ b/lib/api/video.js
@@ -359,6 +359,16 @@ class Video extends ApiResource {
     return this.context.authRequest('post', `/videos/${videoId}/thumbnail/frame.json`, qs.stringify(opts))
   }
 
+  /**
+   * Get the video's download details: download URL, expiration time and status.
+   *
+   * @param {Number} videoId - ID of existing video
+   * @param {string} format - The downloadable format: mp4 or flv.
+   */
+  getDownloadDetails (videoId, format) {
+    return this.context.authRequest('get', `/videos/${videoId}/downloadable/${format}.json`)
+  }
+
 }
 
 module.exports = Video


### PR DESCRIPTION
@MichaelJamesParsons , here's a new PR that contains the API call that gets a video's download details:

- Download URL
- The expiration time (timestamp)
- Status: available, unavailable or pending

I've rebased the branch first, I guess #28 can be close. Thank you for the hint.