### PR TITLE
Set auth url depending on API endpoint (IBM or Ustream)

### DIFF
--- a/lib/ustream.js
+++ b/lib/ustream.js
@@ -137,7 +137,7 @@ class Ustream {
    *
    */
   getAuthUrl () {
-    return API_AUTH_ENDPOINT
+    return this.endpoint.indexOf('video.ibm.com') !== -1 ? 'https://video.ibm.com' : API_AUTH_ENDPOINT
   }
 
   // noinspection JSMethodCanBeStatic


### PR DESCRIPTION
In case the optional **endpoint** field is provided while instantiating the SDK we can implicitly choose https://www.ustream.tv or https://video.ibm.com as the auth URL.
Just to keep the requests consistent by using the same root domain.